### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @software-mansion/scarb-maintainers
+* @maciektr


### PR DESCRIPTION
I forgot that team is not present in the labs org. Assigning manually to @maciektr manually.